### PR TITLE
Max scale

### DIFF
--- a/lib/pinch-zoom.ts
+++ b/lib/pinch-zoom.ts
@@ -81,7 +81,7 @@ function createPoint(): SVGPoint {
 }
 
 const MIN_SCALE = 0.01;
-const MAX_SCALE = 100;
+const MAX_SCALE = Infinity;
 
 export default class PinchZoom extends HTMLElement {
   // The element that we'll transform.

--- a/lib/pinch-zoom.ts
+++ b/lib/pinch-zoom.ts
@@ -30,6 +30,7 @@ interface SetTransformOpts extends ChangeOptions {
 type ScaleRelativeToValues = 'container' | 'content';
 
 const minScaleAttr = 'min-scale';
+const maxScaleAttr = 'max-scale';
 
 export interface ScaleToOpts extends ChangeOptions {
   /** Transform origin. Can be a number, or string percent, eg "50%" */
@@ -80,6 +81,7 @@ function createPoint(): SVGPoint {
 }
 
 const MIN_SCALE = 0.01;
+const MAX_SCALE = 100;
 
 export default class PinchZoom extends HTMLElement {
   // The element that we'll transform.
@@ -89,7 +91,7 @@ export default class PinchZoom extends HTMLElement {
   // Current transform.
   private _transform: SVGMatrix = createMatrix();
 
-  static get observedAttributes() { return [minScaleAttr]; }
+  static get observedAttributes() { return [minScaleAttr, maxScaleAttr]; }
 
   constructor() {
     super();
@@ -122,6 +124,11 @@ export default class PinchZoom extends HTMLElement {
         this.setTransform({scale: this.minScale});
       }
     }
+    if (name === maxScaleAttr) {
+      if (this.scale > this.maxScale) {
+        this.setTransform({scale: this.maxScale});
+      }
+    }
   }
 
   get minScale(): number {
@@ -136,6 +143,20 @@ export default class PinchZoom extends HTMLElement {
 
   set minScale(value: number) {
     this.setAttribute(minScaleAttr, String(value));
+  }
+
+  get maxScale(): number {
+    const attrValue = this.getAttribute(maxScaleAttr);
+    if (!attrValue) return MAX_SCALE;
+
+    const value = parseFloat(attrValue);
+    if (Number.isFinite(value)) return Math.min(MAX_SCALE, value);
+
+    return MAX_SCALE;
+  }
+
+  set maxScale(value: number) {
+    this.setAttribute(maxScaleAttr, String(value));
   }
 
   connectedCallback() {
@@ -269,8 +290,9 @@ export default class PinchZoom extends HTMLElement {
    * Update transform values without checking bounds. This is only called in setTransform.
    */
   private _updateTransform(scale: number, x: number, y: number, allowChangeEvent: boolean) {
-    // Avoid scaling to zero
+    // Avoid scaling out of min/max scale
     if (scale < this.minScale) return;
+    if (scale > this.maxScale) return;
 
     // Return if there's no change
     if (


### PR DESCRIPTION
Hi,

I have a use case where I need to limit the max scale of the transformed element. I have forked the repo and added support for the "max-scale" attribute - it is handled in the very same way as the already supported "min-scale". I'd rather use your original package than my fork if you'd be willing to merge this in. Thanks.

